### PR TITLE
[WIP] Remove dependicies to crystal version

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -7,8 +7,6 @@ authors:
 description: |
   Filename sanitization for Crystal
 
-crystal: 0.30.1
-
 license: MIT
 
 dependencies:


### PR DESCRIPTION
It seems the project is not actively develop. Make sure that a project with a new version of crystal can use the shard.